### PR TITLE
denote support for typehints in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Documentation': 'http://async_stagger.readthedocs.io',
     },
     packages=find_packages(),
+    package_data={'async_stagger', ['py.typed']},
     python_requires='>=3.6',
     extras_require={
         'test': ['pytest', 'pytest-asyncio', 'pytest-mock'],


### PR DESCRIPTION
this is done to include typehinting information about this project in its pypi package.

https://www.python.org/dev/peps/pep-0561/#packaging-type-information